### PR TITLE
Update features.txt

### DIFF
--- a/features.txt
+++ b/features.txt
@@ -394,15 +394,15 @@ Computed Property Names
 
 Support for computed names in object property definitions.
 
-6| obj = {
+6| let obj = {
 6|     foo: "bar",
-6|     |[| "prop_" + foo() |]:| 42
+6|     |[| "prop_" + foo |]:| 42
 6| };
 
-5| obj = {
+5| var obj = {
 5|     foo: "bar"
 5| };
-5| |obj[| "prop_" + foo() |] =| 42;
+5| |obj[| "prop_" + foo |] =| 42;
 
 Method Properties
 -----------------


### PR DESCRIPTION
Changed "foo" to property references rather than function calls in "Computed Property Names" since the foo's listed are not functions.
Also added let and var as appropriate.

I'm still unsure whether the spec allows use of other properties defined on the same object as shown ( which currently yields "ReferenceError: foo is not defined" ) and that portions is just not implemented in my current browser, or if the following would be a more appropriate example:

6| let foo = "bar";
6| let obj = {
6|     |[| "prop_" + foo |]:| 42
6| };
